### PR TITLE
修复Overleaf宋体字加粗后自动变为方正小标宋简体的问题

### DIFF
--- a/LZUThesis.cls
+++ b/LZUThesis.cls
@@ -164,6 +164,11 @@
 % 连续参考文献横杠连接
 \RequirePackage{cite}
 
+% 修复宋体字在overleaf中无法加粗的问题
+% 参考：https://www.freesion.com/article/1621320426/
+\setCJKfamilyfont{zhsong}[Path={fonts/}, AutoFakeBold = {2.17}]{SimSun}
+\renewcommand{\songti}{\CJKfamily{zhsong}}
+
 
 %=======head and foot
 %页眉页脚


### PR DESCRIPTION
参考：https://www.freesion.com/article/1621320426/
目前在Overleaf中编译，宋体字加粗字体为方正小标宋简体：
![image](https://user-images.githubusercontent.com/43995067/165030547-03f59391-b17d-45c6-8221-dbc54ce5f10e.png)

修复后：
![image](https://user-images.githubusercontent.com/43995067/165030606-1ed4618c-48e7-414c-8457-e5ce9b22ecd6.png)

Signed-off-by: Hollow Man <hollowman@opensuse.org>